### PR TITLE
A bug and an improvement

### DIFF
--- a/lib/savage/parser.rb
+++ b/lib/savage/parser.rb
@@ -18,7 +18,7 @@ module Savage
           subpaths = []
           if move_index = parsable.index(/[Mm]/)
             subpaths << parsable[0...move_index] if move_index > 0
-            parsable.scan /[Mm](?:\d|[.,-]|[LlHhVvQqCcTtSsAaZz]|\W)+/m do |match_group|
+            parsable.scan /[Mm](?:\d|[eE.,-]|[LlHhVvQqCcTtSsAaZz]|\W)+/m do |match_group|
               subpaths << $&
             end
           else
@@ -35,7 +35,7 @@ module Savage
         
         def extract_directions(parsable)
           directions = []
-          parsable.scan /[MmLlHhVvQqCcTtSsAaZz](?:\d|[.,-]|\W)*/m do |match_group|
+          parsable.scan /[MmLlHhVvQqCcTtSsAaZz](?:\d|[eE.,-]|\W)*/m do |match_group|
             direction = build_direction $&
             if direction.kind_of?(Array)
               directions.concat direction
@@ -129,7 +129,7 @@ module Savage
         
         def extract_coordinates(command_string)
           coordinates = []
-          command_string.scan(/-?\d+(\.\d+)?/) do |match_group|
+          command_string.scan(/-?\d+(\.\d+)?([eE]-?\d+)?/) do |match_group|
             coordinates << $&.to_f
           end
           coordinates

--- a/spec/savage/parser_spec.rb
+++ b/spec/savage/parser_spec.rb
@@ -191,5 +191,12 @@ describe Parser do
       path.subpaths[0].directions.length.should == 2
       path.subpaths[1].directions.length.should == 6
     end
+		
+		it "should support scienfitic notation in paths (eg. 2e-5)" do
+			# this is a 100x100 square
+			path = Parser.parse "M 0,0 L 1e2,0 100,1000e-1 L 0,100"
+			points = path.directions.map{|d| [d.target.x, d.target.y] }
+			points.should == [[0.0, 0.0], [100.0, 0.0], [100.0, 100.0], [0.0, 100.0]]
+		end
   end
 end


### PR DESCRIPTION
1. Savage didn't support scientific notation in coordinates (eg 2e-5). This was a simple fix, I just fixed some regexes, and added a test.
2. Due to recursion in def build_direction Savage would sometimes blow up with SystemStackError. I changed that function, so it iteratively parses all coordinates in once call. (I'm also pretty sure it got a little bit faster, although I didn't do any benchmarks - I removed some ugly string munging.) I didn't add any tests here, since for some unexplainable reason it didn't explode in tests, but did in real life - here's a reduced example: https://gist.github.com/1422746, if it behaves "correctly" for you, you can just copy it verbatim.
