### PR TITLE
Get rid of ActiveSupport dependency

### DIFF
--- a/lib/savage.rb
+++ b/lib/savage.rb
@@ -1,8 +1,3 @@
-begin
-  require 'active_support/core_ext/string/inflections'
-rescue LoadError, NameError
-  require 'activesupport'
-end
 SAVAGE_PATH = File.dirname(__FILE__) + "/savage/"
 [
   'utils',

--- a/lib/savage/sub_path.rb
+++ b/lib/savage/sub_path.rb
@@ -7,7 +7,7 @@ module Savage
       define_method(sym) do |*args|
         raise TypeError if const == "QuadraticCurveTo" && @directions.last.class != Directions::QuadraticCurveTo && [2,3].include?(args.length)
         raise TypeError if const == "CubicCurveTo" && @directions.last.class != Directions::CubicCurveTo && [4,5].include?(args.length)
-        (@directions << ("Savage::Directions::" << const).constantize.new(*args)).last
+        (@directions << Savage::Directions.const_get(const).new(*args)).last
       end
     end
 


### PR DESCRIPTION
All that machinery just to use once?

As far as I can see you're using ActiveSupport only to call String#constantize once. This get rid of this one call, replacing it with good old Module#const_get from the core. Specs still pass.

Make sure to update gem dependencies if you accept this change :)
