### PR TITLE
Directions have abstract array representation

### DIFF
--- a/lib/savage/direction.rb
+++ b/lib/savage/direction.rb
@@ -2,17 +2,22 @@ module Savage
   module Directions
     Point = Struct.new :x, :y
   end
-  
+
   class Direction
-    
+
     include Utils
-    
+
     def initialize(absolute)
       @absolute = absolute
     end
-    
+
     def absolute?
       @absolute
+    end
+
+    def to_command
+      arr = to_a
+      arr[0] + arr[1..-1].join(' ').gsub(/ -/,'-')
     end
   end
 end

--- a/lib/savage/directions/arc_to.rb
+++ b/lib/savage/directions/arc_to.rb
@@ -2,7 +2,7 @@ module Savage
   module Directions
     class ArcTo < PointTarget
       attr_accessor :radius, :rotation, :large_arc, :sweep
-    
+
       def initialize(radius_x, radius_y, rotation, large_arc, sweep, target_x, target_y, absolute=true)
         super(target_x, target_y, absolute)
         @radius = Point.new(radius_x, radius_y)
@@ -10,11 +10,11 @@ module Savage
         @large_arc = large_arc.is_a?(Numeric) ? large_arc > 0 : large_arc
         @sweep = sweep.is_a?(Numeric) ? sweep > 0 : sweep
       end
-    
-      def to_command
-        command_code << "#{@radius.x} #{@radius.y} #{@rotation} #{bool_to_int(@large_arc)} #{bool_to_int(@sweep)} #{target.x} #{target.y}".gsub(/ -/,'-')
+
+      def to_a
+        [command_code, @radius.x, @radius.y, @rotation, bool_to_int(@large_arc), bool_to_int(@sweep), target.x, target.y]
       end
-      
+
       def command_code
         (absolute?) ? 'A' : 'a'
       end

--- a/lib/savage/directions/close_path.rb
+++ b/lib/savage/directions/close_path.rb
@@ -1,15 +1,15 @@
 module Savage
   module Directions
     class ClosePath < Direction
-    
+
       def initialize(absolute=true)
         super(absolute)
       end
-    
-      def to_command
-        command_code
+
+      def to_a
+        [command_code]
       end
-      
+
       def command_code
         (absolute?) ? 'Z' : 'z'
       end

--- a/lib/savage/directions/coordinate_target.rb
+++ b/lib/savage/directions/coordinate_target.rb
@@ -1,16 +1,16 @@
 module Savage
   module Directions
     class CoordinateTarget < Direction
-    
+
       attr_accessor :target
-    
+
       def initialize(target, absolute=true)
         @target = target
         super(absolute)
       end
-    
-      def to_command
-        command_code << @target.to_s
+
+      def to_a
+        [command_code, @target.to_s]
       end
     end
   end

--- a/lib/savage/directions/cubic_curve_to.rb
+++ b/lib/savage/directions/cubic_curve_to.rb
@@ -2,7 +2,7 @@ module Savage
   module Directions
     class CubicCurveTo < QuadraticCurveTo
       attr_accessor :control_1
-    
+
       def initialize(*args)
         raise ArgumentError if args.length < 4
         case args.length
@@ -19,14 +19,18 @@ module Savage
           super(args[2],args[3],args[4],args[5],args[6])
         end
       end
-    
-      def to_command
-        command_code << ((@control_1) ? "#{@control_1.x} #{@control_1.y} #{@control.x} #{@control.y} #{@target.x} #{@target.y}".gsub(/ -/,'-') : super().gsub(/[A-Za-z]/,''))
+
+      def to_a
+        if @control_1
+          [command_code, @control_1.x, @control_1.y, @control.x, @control.y, @target.x, @target.y]
+        else
+          [command_code, @control.x, @control.y, @target.x, @target.y]
+        end
       end
-    
+
       def control_2; @control; end
       def control_2=(value); @control = value; end
-  
+
       def command_code
         return (absolute?) ? 'C' : 'c' if @control_1
         (absolute?) ? 'S' : 's'

--- a/lib/savage/directions/point_target.rb
+++ b/lib/savage/directions/point_target.rb
@@ -1,16 +1,16 @@
 module Savage
   module Directions
     class PointTarget < Direction
-    
+
       attr_accessor :target
-    
+
       def initialize(x, y, absolute=true)
         @target = Point.new(x,y)
         super(absolute)
       end
-    
-      def to_command
-        command_code << "#{@target.x.to_s} #{@target.y.to_s}".gsub(/ -/,'-')
+
+      def to_a
+        [command_code, @target.x, @target.y]
       end
     end
   end

--- a/lib/savage/directions/quadratic_curve_to.rb
+++ b/lib/savage/directions/quadratic_curve_to.rb
@@ -2,7 +2,7 @@ module Savage
   module Directions
     class QuadraticCurveTo < PointTarget
       attr_accessor :control
-    
+
       def initialize(*args)
         raise ArgumentError if args.length < 2
         case args.length
@@ -19,9 +19,13 @@ module Savage
           super(args[2],args[3],args[4])
         end
       end
-    
-      def to_command
-        command_code << ((@control) ? "#{@control.x} #{@control.y} #{@target.x} #{@target.y}".gsub(/ -/,'-') : super().gsub(/[A-Za-z]/,''))
+
+      def to_a
+        if @control
+          [command_code, @control.x, @control.y, @target.x, @target.y]
+        else
+          [command_code, @target.x, @target.y]
+        end
       end
 
       def command_code

--- a/lib/savage/path.rb
+++ b/lib/savage/path.rb
@@ -2,30 +2,30 @@ module Savage
   class Path
     require File.dirname(__FILE__) + "/direction_proxy"
     require File.dirname(__FILE__) + "/sub_path"
-    
+
     include Utils
     include DirectionProxy
-    
+
     attr_accessor :subpaths
-    
+
     define_proxies do |sym,const|
       define_method(sym) do |*args|
         @subpaths.last.send(sym,*args)
-      end 
+      end
     end
-    
+
     def initialize(*args)
       @subpaths = [SubPath.new]
       @subpaths.last.move_to(*args) if (2..3).include?(*args.length)
       yield self if block_given?
     end
-    
+
     def directions
       directions = []
       @subpaths.each { |subpath| directions.concat(subpath.directions) }
       directions
     end
-    
+
     def move_to(*args)
       unless (@subpaths.last.directions.empty?)
         (@subpaths << SubPath.new(*args)).last
@@ -33,11 +33,11 @@ module Savage
         @subpaths.last.move_to(*args)
       end
     end
-    
+
     def closed?
       @subpaths.last.closed?
     end
-    
+
     def to_command
       @subpaths.collect { |subpath| subpath.to_command }.join
     end

--- a/spec/savage/path_spec.rb
+++ b/spec/savage/path_spec.rb
@@ -22,7 +22,7 @@ describe Path do
     path.subpaths.last.directions[1].class.should == Directions::LineTo
     path.subpaths.last.directions[2].class.should == Directions::CubicCurveTo
     path.subpaths.last.directions[3].class.should == Directions::ArcTo
-    
+
     path2 = Path.new do |p|
       p.line_to 300, 400
       p.cubic_curve_to 500,600,700,800,900,1000


### PR DESCRIPTION
This is a pure refactor of the Direction subclasses. it implements `to_command` in terms of `to_a`, which is an abstract representation of each svg command, basically

```
> Savage::Directions::LineTo.new(100,200).to_a
=> ["L", 100, 200]
```

I'm using this to process a large number of documents and then store them as JSON, which are then rendered using [Quartz drawing commands](http://developer.apple.com/library/ios/#documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/Introduction/Introduction.html). I also removed calls to `super().gsub(/[A-Za-z]/,'')` and instead explicitly stated the control points in `to_a`.
