### PR TITLE
Add transformable module so that paths and directions can be transformed

### DIFF
--- a/lib/savage.rb
+++ b/lib/savage.rb
@@ -1,9 +1,3 @@
-SAVAGE_PATH = File.dirname(__FILE__) + "/savage/"
-[
-  'utils',
-  'direction',
-  'path',
-  'parser'
-].each do |library|
-  require SAVAGE_PATH + library
+%w[ utils transformable direction path parser ].each do |library|
+  require_relative "savage/#{library}"
 end

--- a/lib/savage/direction.rb
+++ b/lib/savage/direction.rb
@@ -6,6 +6,7 @@ module Savage
   class Direction
 
     include Utils
+    include Transformable
 
     def initialize(absolute)
       @absolute = absolute
@@ -15,8 +16,15 @@ module Savage
       @absolute
     end
 
+    def relative?
+      !absolute?
+    end
+
     def to_command
       arr = to_a
+      arr.map! do |x|
+        x.to_i == x ? x.to_i : x
+      end
       arr[0] + arr[1..-1].join(' ').gsub(/ -/,'-')
     end
   end

--- a/lib/savage/directions/arc_to.rb
+++ b/lib/savage/directions/arc_to.rb
@@ -18,6 +18,12 @@ module Savage
       def command_code
         (absolute?) ? 'A' : 'a'
       end
+
+      def transform(scale_x, skew_x, skew_y, scale_y, tx, ty)
+        # relative arc_to dont't need to be tranlated
+        tx = ty = 0 if relative?
+        transform_dot( target,  scale_x, skew_x, skew_y, scale_y, tx, ty)
+      end
     end
   end
 end

--- a/lib/savage/directions/coordinate_target.rb
+++ b/lib/savage/directions/coordinate_target.rb
@@ -10,7 +10,7 @@ module Savage
       end
 
       def to_a
-        [command_code, @target.to_s]
+        [command_code, @target]
       end
     end
   end

--- a/lib/savage/directions/horizontal_to.rb
+++ b/lib/savage/directions/horizontal_to.rb
@@ -4,6 +4,16 @@ module Savage
       def command_code
         (absolute?) ? 'H' : 'h'
       end
+
+      def transform(scale_x, skew_x, skew_y, scale_y, tx, ty)
+
+        unless skew_y.zero?
+          raise 'rotating or skewing (in Y axis) an "horizontal_to" direction is not supported yet.'
+        end
+        
+        self.target *= scale_x
+        self.target += tx if absolute?
+      end
     end
   end
 end

--- a/lib/savage/directions/line_to.rb
+++ b/lib/savage/directions/line_to.rb
@@ -4,6 +4,12 @@ module Savage
       def command_code
         (absolute?) ? 'L' : 'l'
       end
+
+      def transform(scale_x, skew_x, skew_y, scale_y, tx, ty)
+        # relative line_to dont't need to be tranlated
+        tx = ty = 0 if relative?
+        transform_dot( target, scale_x, skew_x, skew_y, scale_y, tx, ty)
+      end
     end
   end
 end

--- a/lib/savage/directions/move_to.rb
+++ b/lib/savage/directions/move_to.rb
@@ -4,6 +4,12 @@ module Savage
       def command_code
         (absolute?) ? 'M' : 'm'
       end
+
+      def transform(scale_x, skew_x, skew_y, scale_y, tx, ty)
+        # relative move_to dont't need to be tranlated
+        tx = ty = 0 if relative?
+        transform_dot( target, scale_x, skew_x, skew_y, scale_y, tx, ty )
+      end
     end
   end
 end

--- a/lib/savage/directions/quadratic_curve_to.rb
+++ b/lib/savage/directions/quadratic_curve_to.rb
@@ -32,6 +32,13 @@ module Savage
         return (absolute?) ? 'Q' : 'q' if @control
         (absolute?) ? 'T' : 't'
       end
+
+      def transform(scale_x, skew_x, skew_y, scale_y, tx, ty)
+        # relative line_to dont't need to be tranlated
+        tx = ty = 0 if relative?
+        transform_dot( target,  scale_x, skew_x, skew_y, scale_y, tx, ty)
+        transform_dot( control, scale_x, skew_x, skew_y, scale_y, tx, ty)
+      end
     end
   end
 end

--- a/lib/savage/directions/quadratic_curve_to.rb
+++ b/lib/savage/directions/quadratic_curve_to.rb
@@ -37,7 +37,7 @@ module Savage
         # relative line_to dont't need to be tranlated
         tx = ty = 0 if relative?
         transform_dot( target,  scale_x, skew_x, skew_y, scale_y, tx, ty)
-        transform_dot( control, scale_x, skew_x, skew_y, scale_y, tx, ty)
+        transform_dot( control, scale_x, skew_x, skew_y, scale_y, tx, ty) if control
       end
     end
   end

--- a/lib/savage/directions/vertical_to.rb
+++ b/lib/savage/directions/vertical_to.rb
@@ -4,6 +4,16 @@ module Savage
       def command_code
         (absolute?) ? 'V' : 'v'
       end
+
+      def transform(scale_x, skew_x, skew_y, scale_y, tx, ty)
+
+        unless skew_x.zero?
+          raise 'rotating or skewing (in X axis) an "vertical_to" direction is not supported yet.'
+        end
+        
+        target *= scale_y
+        target += ty if absolute?
+      end
     end
   end
 end

--- a/lib/savage/directions/vertical_to.rb
+++ b/lib/savage/directions/vertical_to.rb
@@ -11,8 +11,8 @@ module Savage
           raise 'rotating or skewing (in X axis) an "vertical_to" direction is not supported yet.'
         end
         
-        target *= scale_y
-        target += ty if absolute?
+        self.target *= scale_y
+        self.target += ty if absolute?
       end
     end
   end

--- a/lib/savage/path.rb
+++ b/lib/savage/path.rb
@@ -5,6 +5,7 @@ module Savage
 
     include Utils
     include DirectionProxy
+    include Transformable
 
     attr_accessor :subpaths
 
@@ -40,6 +41,10 @@ module Savage
 
     def to_command
       @subpaths.collect { |subpath| subpath.to_command }.join
+    end
+
+    def transform(*args)
+      @subpaths.each {|subpath| subpath.transform *args }
     end
   end
 end

--- a/lib/savage/sub_path.rb
+++ b/lib/savage/sub_path.rb
@@ -2,6 +2,7 @@ module Savage
   class SubPath
     include Utils
     include DirectionProxy
+    include Transformable
 
     define_proxies do |sym,const|
       define_method(sym) do |*args|
@@ -44,6 +45,10 @@ module Savage
 
     def closed?
       @directions.last.kind_of? Directions::ClosePath
+    end
+
+    def transform(*args)
+      directions.each { |dir| dir.transform *args }
     end
   end
 end

--- a/lib/savage/transformable.rb
+++ b/lib/savage/transformable.rb
@@ -1,0 +1,48 @@
+require 'bigdecimal'
+require 'bigdecimal/util'
+
+module Savage
+
+  module Transformable
+
+    # Matrix:
+    def transform(scale_x, skew_x, skew_y, scale_y, tx, ty)
+    end
+
+    def translate(tx, ty=0)
+      transform( 1, 0, 0, 1, tx, ty )
+    end
+
+    def scale(sx, sy=sx)
+      transform( sx, 0, 0, sy, 0, 0 )
+    end
+
+    # TODO:
+    # make cx, cy be origin center
+    def rotate( angle, cx=0, cy=0 )
+      a = (angle.to_f/180).to_d * Math::PI
+      translate( cx, cy )
+      transform( Math.cos(a),  Math.sin(a), -Math.sin(a), Math.cos(a), 0, 0)
+      translate( -cx, -cy )
+    end
+
+    def skew_x( angle )
+      a = angle.to_f/180 * Math::PI
+      transform( 1, 0, Math.tan(a), 1, 0, 0 )
+    end
+
+    def skew_y( angle )
+      a = angle.to_f/180 * Math::PI
+      transform( 1, Math.tan(a), 0, 1, 0, 0 )
+    end
+
+    protected
+
+      def transform_dot( dot, scale_x, skew_x, skew_y, scale_y, tx, ty )
+        x, y  = dot.x, dot.y
+        dot.x = x*scale_x + y*skew_x  + tx
+        dot.y = x*skew_y  + y*scale_y + ty
+      end
+
+  end
+end

--- a/spec/savage/parser_spec.rb
+++ b/spec/savage/parser_spec.rb
@@ -227,13 +227,13 @@ describe Parser do
     end
 
     it 'should generate the same string given to it (assuming float values are used), if not changed in the interim' do
-      path_string = "M100.0 200.0A255.0 12.0-123.0 1 0 23.0-93.4L100.0 200.0 300.0 400.0Q1.233-34.0 255.0 12.0T255.0 12.0H-342.65Z"
+      path_string = "M100 200A255 12-123 1 0 23-93.4L100 200 300 400Q1.233-34 255 12T255 12H-342.65Z"
       path = Parser.parse(path_string)
       path.to_command.should == path_string
     end
 
     it "should be able to parse complex paths" do
-      path = Parser.parse("M74.89,146.249c0.042,0.552,0.376,0.685,0.744,0.293m50.543-9.1323c15.445-16.43,32.782-32.859,49.793-49.289    c-6.298,0.001-12.595,0.001-18.893,0c-10.813,10.37-21.759,20.737-32.275,31.107C74.249,134.323,74.424,140.285,74.89,146.249z")
+      path = Parser.parse("M74.89,146.249c042,0.552,0.376,0.685,0.744,0.293m50.543-9.1323c15.445-16.43,32.782-32.859,49.793-49.289    c-6.298,001-12.595,001-18.893,0c-10.813,10.37-21.759,20.737-32.275,31.107C74.249,134.323,74.424,140.285,74.89,146.249z")
       path.class.should == Path
       path.subpaths.length.should == 2
       path.subpaths[0].directions.length.should == 2
@@ -244,7 +244,7 @@ describe Parser do
       # this is a 100x100 square
       path = Parser.parse "M 0,0 L 1e2,0 100,1000e-1 L 0,10e+1"
       points = path.directions.map{|d| [d.target.x, d.target.y] }
-      points.should == [[0.0, 0.0], [100.0, 0.0], [100.0, 100.0], [0.0, 100.0]]
+      points.should == [[0, 0], [100, 0], [100, 100], [0, 100]]
     end
   end
 end

--- a/spec/savage/transformable_spec.rb
+++ b/spec/savage/transformable_spec.rb
@@ -1,0 +1,62 @@
+require_relative '../spec_helper'
+
+include Savage
+
+describe Transformable do
+  it 'should apply to Path, SubPath and Direction' do
+    [Path, SubPath, Direction, Directions::LineTo].each do |cls|
+      expect(cls.ancestors).to include(Transformable)
+      expect(cls.public_instance_methods).to include(:transform)
+    end
+  end
+
+  describe Path do
+    it 'should transfrom subpaths recursively' do
+      path = Parser.parse('M 0 100 L 100 200 L 200 200 H 30 M 0 100 Z')
+      path.translate( 100, -135 )
+      path.subpaths.first.to_command.should == "M100-35 200 65 300 65H130"
+      path.subpaths[1].to_command.should == "M100-35Z"
+    end
+  end
+
+  describe SubPath do
+    it 'should transfrom subpaths recursively' do
+      path = Parser.parse('M 0 100 L 100 200 L 200 200 H 30 M 0 100 Z')
+      subpath = path.subpaths.first
+      subpath.translate( 10, 15 )
+      subpath.directions.first.to_command.should == "M10 115"
+      subpath.directions[1].to_command.should == "L110 215"
+      subpath.directions[2].to_command.should == "L210 215"
+      subpath.directions[3].to_command.should == "H40"
+    end
+  end
+
+  describe Directions::LineTo do
+    it 'could be translate' do
+      x, y = 50, 80
+      dir = Directions::LineTo.new(x, y)
+      dir.translate( 130, 601 )
+      dir.target.x.should == 180
+      dir.target.y.should == 681
+    end
+
+    it 'should ignore translating if relative' do
+      x, y = 50, 80
+      dir = Directions::LineTo.new(x, y, false)
+      dir.translate( 130, 601 )
+      # notice: not changed
+      dir.target.x.should == 50
+      dir.target.y.should == 80
+    end
+
+    it 'could be rotated' do
+      x, y = 50, 80
+      dir = Directions::LineTo.new(x, y)
+      dir.rotate(90)
+      dir.target.x.should == 80
+      dir.target.y.round.should == -50
+    end
+  end
+end
+
+


### PR DESCRIPTION
Paths, sub paths and directions can be transformed now. e.g.

``` ruby
path.translate    tx, ty
sub_path.rotate   90
direction.skew_x  20
```

Transforming paths cause their sub paths transformed.
Transforming sub paths cause their directions transformed.

Some kinds of transforming are not supported yet:
rotating, skewing on H/h, V/v commands because this cause commands to other types ( H/h -> L/l )
We may implement them later.

I made change because in my project i needed to transform all paths recursively.
I'm not quite sure if it is good to merge this pull request.
what do you think? :)
